### PR TITLE
Fix disappearing chat message issue on rare occasions

### DIFF
--- a/code/ui/ClassicChatEntry.cs
+++ b/code/ui/ClassicChatEntry.cs
@@ -22,7 +22,7 @@ public partial class ClassicChatEntry : Panel
 	{
 		base.Tick();
 
-		if ( TimeSinceBorn > 3 )
+		if ( TimeSinceBorn > 3 && !ClassicChatBox.Current.HasClass( "open" ) )
 		{
 			Hide();
 		}


### PR DESCRIPTION
Alex — Today at 5:17 PM
the bug where
if you type something
and then immediately open the chat
the new message disappears after 3 seconds